### PR TITLE
Fixed some argument ordering

### DIFF
--- a/src/RamDisk.csproj
+++ b/src/RamDisk.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net40;net45;net461;</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net48;net6.0;</TargetFrameworks>
     <LangVersion>9.0</LangVersion>
     <AssemblyName>RamDisk</AssemblyName>
     <PackageId>RamDisk</PackageId>

--- a/src/RamDrive.cs
+++ b/src/RamDrive.cs
@@ -45,7 +45,7 @@ namespace RamDisk
             if (megaBytes <= 0)
                 throw new ArgumentException("Allocation size must be greater than zero.", nameof(megaBytes));
             if (string.IsNullOrWhiteSpace(volumeLabel))
-                throw new ArgumentNullException("Volume label muste be not null or empty.", nameof(volumeLabel));
+                throw new ArgumentNullException(nameof(volumeLabel), "Volume label muste be not null or empty.");
             if (DriveInfo.GetDrives().Any(d => d.Name.ToUpper()[0] == driveLetter))
                 throw new InvalidOperationException($"Drive '{driveLetter}' already exists.");
 

--- a/test/RamDisk.Tests.csproj
+++ b/test/RamDisk.Tests.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <TargetFramework>net5.0</TargetFramework>
     <IsPackable>false</IsPackable>
+    <ApplicationManifest>app.manifest</ApplicationManifest>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/RamDisk.Tests.csproj
+++ b/test/RamDisk.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0-windows</TargetFramework>
     <IsPackable>false</IsPackable>
     <ApplicationManifest>app.manifest</ApplicationManifest>
   </PropertyGroup>

--- a/test/RamDriveTests.cs
+++ b/test/RamDriveTests.cs
@@ -44,19 +44,19 @@ namespace RamDisk.Tests
         [Test]
         public void Drive_Name_ShouldBe_Z()
         {
-            Assert.AreEqual(Drive.Name, "X:\\");
+            Assert.AreEqual("X:\\", Drive.Name);
         }
 
         [Test]
         public void Drive_Label_ShouldBe_RamDisk()
         {
-            Assert.AreEqual(Drive.VolumeLabel, "MyDriveName");
+            Assert.AreEqual("MyDriveName", Drive.VolumeLabel);
         }
 
         [Test]
         public void Drive_Format_ShouldBe_NTFS()
         {
-            Assert.AreEqual(Drive.DriveFormat, FileSystem.NTFS.ToString());
+            Assert.AreEqual(FileSystem.NTFS.ToString(), Drive.DriveFormat);
         }
 
         [Test]
@@ -64,7 +64,7 @@ namespace RamDisk.Tests
         {
             decimal kb = 1024;
             var size = Math.Round(Drive.TotalSize / kb / kb);
-            Assert.AreEqual(size, 128);
+            Assert.AreEqual(128, size);
         }
 
         [Test]

--- a/test/app.manifest
+++ b/test/app.manifest
@@ -1,0 +1,17 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<assembly manifestVersion="1.0" xmlns="urn:schemas-microsoft-com:asm.v1">
+  <assemblyIdentity version="1.0.0.0" name="MyApplication.app"/>
+  <trustInfo xmlns="urn:schemas-microsoft-com:asm.v2">
+    <security>
+      <requestedPrivileges xmlns="urn:schemas-microsoft-com:asm.v3">
+        <requestedExecutionLevel level="requireAdministrator" uiAccess="false" />
+      </requestedPrivileges>
+    </security>
+  </trustInfo>
+
+  <compatibility xmlns="urn:schemas-microsoft-com:compatibility.v1">
+    <application>
+      <supportedOS Id="{8e0f7a12-bfb3-4fe8-b9a5-48fd50a15a9a}" />
+    </application>
+  </compatibility>
+</assembly>


### PR DESCRIPTION
 - Fixed the argument order for test `Assert` (he first argument should be the expected value, and the second argument the actual value)
 - Fixed `ArgumentNullException` argument order
 - Added an `app.manifest` with the `requestedExecutionLevel` set to `requireAdministrator`
 - Updated target frameworks (.NET Framework to 4.8 and andded .NET 6)